### PR TITLE
Optional changes to lights/siren handling for ELS cars

### DIFF
--- a/AssortedCallouts/Assorted Callouts.ini
+++ b/AssortedCallouts/Assorted Callouts.ini
@@ -1,0 +1,97 @@
+//Welcome to the INI file of Assorted Callouts by Albo1125. Last updated for version 0.6.4.0.
+//Please read the bundled licence.
+
+//FOR ALL KEYBINDINGS:
+// Use the exact 'member name' for the corresponding keyboard key: https://msdn.microsoft.com/en-us/library/system.windows.forms.keys(v=vs.110).aspx 
+// Stuff that's true/false by default can be set to 'true' or 'false' without quotation marks.
+
+// Some values can be either 'true' or 'false'.
+
+[General]
+//Set this to BritishEnglish or AmericanEnglish
+Language=BritishEnglish
+
+OtherUnitTakingCallAudio=true
+
+//Ingame, dispatch will call you in the following format: Division-UnitType-Beat.
+//Division can be set to any number from 1 to 10 inclusive. Default=1
+Division=1
+
+//UnitType can be set to any of the file names in the following folder: Grand Theft Auto V/LSPDFR/Police Scanner/Assorted Callouts Audio/UNIT_TYPE. Default=LINCOLN
+UnitType=LINCOLN
+
+//Beat can be set to any number from 1 to 24 inclusive. Default=18
+Beat=18
+
+[Global Keybindings]
+TalkKey=Y
+
+//This key can only be used when indicated.
+EndCallKey=End
+
+[HotPursuit]
+HotPursuitEnabled=true
+HotPursuitFrequency=2
+
+[Shoplifting]
+ShopliftingEnabled=true
+ShopliftingFrequency=2
+
+[Prisoner Transport Required]
+PrisonerTransportRequiredEnabled=true
+PrisonerTransportRequiredFrequency=2
+
+[Stolen Police Vehicle]
+StolenPoliceVehicleEnabled=true
+StolenPoliceVehicleFrequency=2
+
+[Traffic Stop Backup]
+TrafficStopBackupEnabled=true
+TrafficStopBackupFrequency=2
+
+// Set this to true to have AI officers leave their emergency lights off on ELS-enabled cars. This is the only way to stop
+// them blaring the siren whenever they are in their vehicle with the lights on!
+LightsOffForELSCars=false
+
+[Petrol Theft]
+PetrolTheftEnabled=true
+PetrolTheftFrequency=2
+
+[Solicitation]
+SolicitationEnabled=true
+SolicitationFrequency=2
+
+//Here you can set your unmarked police vehicle(s) if you changed them - the hooker will be less aware of you if you're in this vehicle.
+//Separate multiple vehicles with commas, e.g.: UnmarkedVehicles=POLICE, POLICE2, POLICE3
+UnmarkedVehicles=POLICE4
+
+//True/false depending on whether you only want this callout to be able to occur during nightly hours (20:30-05:30)
+NightOnly=false
+
+[Person with a knife]
+PersonKnifeEnabled=true
+PersonKnifeFrequency=2
+
+[Organised Street Race]
+OrganisedStreetRaceEnabled=true
+OrganisedStreetRaceFrequency=2
+
+[Illegal Immigrants in Truck]
+IllegalImmigrantsInTruckEnabled=true
+IllegalImmigrantsInTruckFrequency=2
+
+[StoreRobbery]
+StoreRobberyEnabled=true
+StoreRobberyFrequency=2
+
+[Bank Heist]
+BankHeistEnabled=true
+BankHeistFrequency=2
+BankHeistVoiceOvers=true
+
+//Bank Heist Callout Keybindings
+RescueHostageKey=D0
+ToggleAlarmKey=F11
+
+//Key to make SWAT follow you.
+FollowKey=I

--- a/AssortedCallouts/AssortedCallouts.csproj
+++ b/AssortedCallouts/AssortedCallouts.csproj
@@ -149,6 +149,11 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </COMReference>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assorted Callouts.ini">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>REM copy /Y "$(TargetDir)$(ProjectName).dll" "G:\Program Files\Rockstar Games\Grand Theft Auto V\Plugins\LSPDFR

--- a/AssortedCallouts/AssortedCallouts.csproj
+++ b/AssortedCallouts/AssortedCallouts.csproj
@@ -151,8 +151,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetDir)$(ProjectName).dll" "G:\Program Files\Rockstar Games\Grand Theft Auto V\Plugins\LSPDFR
-copy /Y "$(TargetDir)$(ProjectName).pdb" "G:\Program Files\Rockstar Games\Grand Theft Auto V\Plugins\LSPDFR</PostBuildEvent>
+    <PostBuildEvent>REM copy /Y "$(TargetDir)$(ProjectName).dll" "G:\Program Files\Rockstar Games\Grand Theft Auto V\Plugins\LSPDFR
+REM copy /Y "$(TargetDir)$(ProjectName).pdb" "G:\Program Files\Rockstar Games\Grand Theft Auto V\Plugins\LSPDFR</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/AssortedCallouts/Callouts/TrafficStopBackup.cs
+++ b/AssortedCallouts/Callouts/TrafficStopBackup.cs
@@ -102,8 +102,18 @@ namespace AssortedCallouts.Callouts
         {
             PoliceCar = new Vehicle(CopCarModel, SpawnPoint, SpawnHeading);
             PoliceCar.MakePersistent();
-            PoliceCar.IsSirenOn = true;
-            PoliceCar.IsSirenSilent = true;
+
+            if (AssortedCalloutsHandler.LightsOffForELSCars && Albo1125.Common.CommonLibrary.ExtensionMethods.VehicleModelIsELS(PoliceCar))
+            {
+                PoliceCar.IsSirenOn = false;
+                PoliceCar.IsSirenSilent = false;
+            }
+            else
+            {
+                PoliceCar.IsSirenOn = true;
+                PoliceCar.IsSirenSilent = true;
+            }
+
             PoliceOfficer = PoliceCar.CreateRandomDriver();
             PoliceOfficer.MakeMissionPed();
             PoliceOfficerBlip = PoliceOfficer.AttachBlip();

--- a/AssortedCallouts/Callouts/TrafficStopBackup.cs
+++ b/AssortedCallouts/Callouts/TrafficStopBackup.cs
@@ -103,7 +103,7 @@ namespace AssortedCallouts.Callouts
             PoliceCar = new Vehicle(CopCarModel, SpawnPoint, SpawnHeading);
             PoliceCar.MakePersistent();
 
-            if (AssortedCalloutsHandler.LightsOffForELSCars && Albo1125.Common.CommonLibrary.ExtensionMethods.VehicleModelIsELS(PoliceCar))
+            if (AssortedCalloutsHandler.LightsOffForELSCars && PoliceCar.VehicleModelIsELS())
             {
                 PoliceCar.IsSirenOn = false;
                 PoliceCar.IsSirenSilent = false;
@@ -193,7 +193,7 @@ namespace AssortedCallouts.Callouts
                         // maybe also turn off lights to ensure siren is off for ELS cars
                         if (AssortedCalloutsHandler.LightsOffForELSCars &&
                             PoliceCar.IsSirenOn &&
-                            Albo1125.Common.CommonLibrary.ExtensionMethods.VehicleModelIsELS(PoliceCar))
+                            PoliceCar.VehicleModelIsELS())
                         {
                             PoliceCar.IsSirenOn = false;
                         }

--- a/AssortedCallouts/Callouts/TrafficStopBackup.cs
+++ b/AssortedCallouts/Callouts/TrafficStopBackup.cs
@@ -186,6 +186,18 @@ namespace AssortedCallouts.Callouts
                         PoliceOfficer.BlockPermanentEvents = true;
                         PoliceOfficer.Tasks.FollowNavigationMeshToPosition(PoliceCar.GetOffsetPosition(Vector3.RelativeLeft * 2f), PoliceCar.Heading, 1.6f).WaitForCompletion(6000);
                         PoliceOfficer.Tasks.EnterVehicle(PoliceCar, 7000, -1).WaitForCompletion();
+
+                        // definitely turn the siren off
+                        PoliceCar.IsSirenSilent = true;
+
+                        // maybe also turn off lights to ensure siren is off for ELS cars
+                        if (AssortedCalloutsHandler.LightsOffForELSCars &&
+                            PoliceCar.IsSirenOn &&
+                            Albo1125.Common.CommonLibrary.ExtensionMethods.VehicleModelIsELS(PoliceCar))
+                        {
+                            PoliceCar.IsSirenOn = false;
+                        }
+
                         PoliceOfficer.Tasks.PerformDrivingManeuver(VehicleManeuver.Wait);
 
                         while (true)

--- a/AssortedCallouts/EntryPoint.cs
+++ b/AssortedCallouts/EntryPoint.cs
@@ -106,7 +106,7 @@ namespace AssortedCallouts
                 IllegalImmigrantsInTruckEnabled = initialiseFile().ReadBoolean("Illegal Immigrants in Truck", "IllegalImmigrantsInTruckEnabled");
                 IllegalImmigrantsInTruckFrequency  = initialiseFile().ReadInt32("Illegal Immigrants in Truck", "IllegalImmigrantsInTruckFrequency", 2);
 
-
+                LightsOffForELSCars = initialiseFile().ReadBoolean("Traffic Stop Backup", "LightsOffForELSCars", false);
 
             }
             catch (Exception e)
@@ -312,6 +312,13 @@ namespace AssortedCallouts
 
         public static string DivisionUnitBeat = "1-ADAM-12";
         public static string DivisionUnitBeatAudioString = "DIV_01 ADAM BEAT_12";
+
+        /// <summary>
+        /// When true, AI officers will not use their lights (and therefore siren) if they are driving
+        /// an ELS vehicle. This prevents, for example, officers sitting on a traffic stop blaring the
+        /// siren. By the way, ELS people, plz can we have api 4 control siren thx. :P
+        /// </summary>
+        public static bool LightsOffForELSCars = false;
 
         public static KeysConverter kc = new KeysConverter();
         


### PR DESCRIPTION
Optional INI setting for leaving the lights off during Traffic Stop Backup on ELS vehicles, where having the lights on causes the siren to blare endlessly while the AI police officer is in the vehicle. (I take the view that not running the lights in this case is less annoying than them running the siren when they wouldn't do this!)

(To the powers that be -- an ELS API for siren control pretty please?)